### PR TITLE
This fixes both issue #3 and issue #22

### DIFF
--- a/src/signalflowgrapher/gui/branch_widget.py
+++ b/src/signalflowgrapher/gui/branch_widget.py
@@ -29,13 +29,13 @@ class BranchWidget(GraphItem):
         self.__pen_width = 3
         # The arrow has the form of a triangle
         # Half of the width of the arrow (at the back)
-        self.__arrow_height = 10
+        self.__arrow_height = 9
         # Length of the arrow from top to back
-        self.__arrow_length = 30
+        self.__arrow_length = 27
         # The triangle is drawn with 3 bezier curves
         # These numbers determine the bend of the curves
         self.__arrow_side_spline_depth = 2
-        self.__arrow_back_spline_depth = 6
+        self.__arrow_back_spline_depth = 5.5
         # Antialiasing offsets for arrow mask
         self.__arrow_mask_length_offset = 8
         self.__arrow_mask_height_offset = 5

--- a/src/signalflowgrapher/io/tikz.py
+++ b/src/signalflowgrapher/io/tikz.py
@@ -110,10 +110,9 @@ class TikZExport(object):
         return code
 
     def __latex_name(self, name: str) -> str:
-        if name=="":
-            latex_notation=""
+        if name == "":
+            latex_notation = ""
         else:
             latex_notation = latex(parse_expr(name, local_dict=_clash),
-                                       mode="inline")
+                                   mode="inline")
         return(latex_notation)
-    

--- a/src/signalflowgrapher/io/tikz.py
+++ b/src/signalflowgrapher/io/tikz.py
@@ -113,6 +113,6 @@ class TikZExport(object):
         if name == "":
             latex_notation = ""
         else:
-            latex_notation = latex(parse_expr(name, local_dict=_clash),
-                                   mode="inline")
+            latex_notation = "$%s$" % latex(parse_expr(name,
+                                                       local_dict=_clash))
         return(latex_notation)

--- a/src/signalflowgrapher/io/tikz.py
+++ b/src/signalflowgrapher/io/tikz.py
@@ -3,6 +3,9 @@ from signalflowgrapher.model.model import Branch, Node
 from signalflowgrapher.io.file import write_file, read_file
 from os.path import dirname, join, isfile
 from shutil import copyfile
+from sympy import latex
+from sympy.parsing.sympy_parser import parse_expr
+from sympy.abc import _clash
 import logging
 logger = logging.getLogger(__name__)
 
@@ -80,7 +83,7 @@ class TikZExport(object):
                         % (index,
                            node.label_dx,
                            node.label_dy,
-                           self.__escape_name(node.name)))
+                           self.__latex_name(node.name)))
         return code
 
     def __get_branches_code(self, branches: Set[Branch], nodes: Set[Node]):
@@ -103,20 +106,11 @@ class TikZExport(object):
             code.append("\\node[ArrowName] at"
                         "($ (middle_%s) + (%s, %s) $) {%s};\n"
                         % (index, branch.label_dx,
-                           branch.label_dy, self.__escape_name(branch.weight)))
+                           branch.label_dy, self.__latex_name(branch.weight)))
         return code
 
-    def __escape_name(self, name: str) -> str:
-        # Escape characters that TeX/TikZ uses
-        characters_to_escape = {"#": r"\#",
-                                "$": r"\$",
-                                "%": r"\%",
-                                "&": r"\&",
-                                "{": r"\{",
-                                "}": r"\}",
-                                "_": r"\_",
-                                "~": r"\~{}",
-                                "^": r"\^{}",
-                                "\\": r"\textbackslash{}"}
-
-        return name.translate(str.maketrans(characters_to_escape))
+    def __latex_name(self, name: str) -> str:
+        latex_notation = latex(parse_expr(name, local_dict=_clash),
+                               mode="inline")
+        return(latex_notation)
+    

--- a/src/signalflowgrapher/io/tikz.py
+++ b/src/signalflowgrapher/io/tikz.py
@@ -110,7 +110,10 @@ class TikZExport(object):
         return code
 
     def __latex_name(self, name: str) -> str:
-        latex_notation = latex(parse_expr(name, local_dict=_clash),
-                               mode="inline")
+        if name=="":
+            latex_notation=""
+        else:
+            latex_notation = latex(parse_expr(name, local_dict=_clash),
+                                       mode="inline")
         return(latex_notation)
     

--- a/src/signalflowgrapher/ressources/tikz/sfgstyle.tex
+++ b/src/signalflowgrapher/ressources/tikz/sfgstyle.tex
@@ -5,14 +5,14 @@
 	% Style of the node
 	Node/.style={circle,thick,draw=black,inner sep=0, minimum size=0.15cm},
 	% Style of the node label
-	NodeName/.style={font=\footnotesize,black, outer sep=1},
+	NodeName/.style={font=\footnotesize,black,outer sep=1},
 	% Style of the branche label
 	ArrowName/.style={font=\footnotesize,auto,outer sep=1},
 	% Style of the branch
 	Connection/.style={thick},
 	->-/.style={decoration={
 			markings,
-			mark=at position #1 with {\draw[->,>=latex',ultra thick](0pt,0)--(4pt,0);}},
+			mark=at position #1 with {\draw[->,>=latex',line width=2pt](0pt,0)--(4pt,0);}},
 		postaction={decorate}},
 	->-/.default=0.50,
 	MarkMiddle/.style={decoration={


### PR DESCRIPTION
I have made the GUI arrows 10% smaller, the LaTeX arrows 25% larger, and let the signalflowgrapher write out node names and branch weights in LaTeX notation.