### PR TITLE
Fixed Bug which caused offset from mouse when pasting

### DIFF
--- a/src/main/python/signalflowgrapher/gui/graph_field.py
+++ b/src/main/python/signalflowgrapher/gui/graph_field.py
@@ -582,8 +582,8 @@ class GraphField(QWidget):
         mouse_x, mouse_y = local_pos.x(), local_pos.y()
 
         # Snap to grid
-        grid_x = int(self.__grid_size*round((mouse_x-self.__grid_offset.x()-2) / self.__grid_size))
-        grid_y =int(self.__grid_size*round((mouse_y-self.__grid_offset.y()-2) / self.__grid_size))
+        grid_x = int(self.__grid_size*round((mouse_x-2) / self.__grid_size))
+        grid_y = int(self.__grid_size*round((mouse_y-2) / self.__grid_size))
 
         # Compute bounding box of copied nodes
         min_x = min(n["x"] for n in nodes_data)


### PR DESCRIPTION
Copy -> Paste works, on original grid. It pastes new nodes right where the mouse is.
When pasting on a moved grid, the new nodes are offset from the mouse's position.

Bug was fixed by not subtracting the __grid_offset() from the mouse position, because the mouse position already incorporates the moved grid.

However there is one bug still remaining:
When pasting on a moved grid, the new nodes might not correctly snap to grid. This is caused by the fact that the grid can be moved fractionally, which currently isn't correctly accounted for by the snapping mechanism.