### PR TITLE
Script to register .SFG file ending on Windows

### DIFF
--- a/tools/windows/README.md
+++ b/tools/windows/README.md
@@ -1,0 +1,8 @@
+### Windows file association
+
+To open `.sfg` files with SignalFlowGrapher and show the app icon in Windows Explorer, run:
+
+- `powershell -ExecutionPolicy Bypass -File .\tools\windows\register_sfg_association.ps1`
+- If you are using a virtual environment, pass the launcher explicitly: `powershell -ExecutionPolicy Bypass -File .\tools\windows\register_sfg_association.ps1 -PythonLauncherPath C:\path\to\pythonw.exe`
+
+This creates a per-user association for `.sfg` files, uses `src\main\icons\Icon.ico` as the file-type icon, and creates a desktop shortcut named `SignalFlowGrapher.lnk`. To remove the association and shortcut again, run the same script with `-Uninstall`.

--- a/tools/windows/README.md
+++ b/tools/windows/README.md
@@ -2,7 +2,13 @@
 
 To open `.sfg` files with SignalFlowGrapher and show the app icon in Windows Explorer, run:
 
-- `powershell -ExecutionPolicy Bypass -File .\tools\windows\register_sfg_association.ps1`
-- If you are using a virtual environment, pass the launcher explicitly: `powershell -ExecutionPolicy Bypass -File .\tools\windows\register_sfg_association.ps1 -PythonLauncherPath C:\path\to\pythonw.exe`
+- To use the system-wide python executable, use:  `powershell -ExecutionPolicy Bypass -File .\tools\windows\register_sfg_association.ps1`
+- Or to specify the path to the `pythonw.exe` excutable, run:  `powershell -ExecutionPolicy Bypass -File .\tools\windows\register_sfg_association.ps1 -PythonLauncherPath C:\path\to\pythonw.exe`
 
 This creates a per-user association for `.sfg` files, uses `src\main\icons\Icon.ico` as the file-type icon, and creates a desktop shortcut named `SignalFlowGrapher.lnk`. To remove the association and shortcut again, run the same script with `-Uninstall`.
+
+#### Virtual Environment
+
+If a virtual environment is used to cleanly install the required packages, use the `-PythonLauncherPath` to pass over the python executable of the virtual environment.
+
+E.g. if you have a virtual environment named `sfg_venv` in the home directory, run the script as following: `powershell -ExecutionPolicy Bypass -File .\tools\windows\register_sfg_association.ps1 -PythonLauncherPath $HOME\sfg_venv\Scripts\pythonw.exe`

--- a/tools/windows/register_sfg_association.ps1
+++ b/tools/windows/register_sfg_association.ps1
@@ -1,0 +1,131 @@
+# PowerShell script to register the .sfg file association for SignalFlowGrapher on Windows.
+# Written by @gfcwfzkm on GitHub.
+# Usage:
+# To register the .sfg file ending, run this script without arguments:
+#     powershell -ExecutionPolicy Bypass -File register_sfg_association.ps1
+# To register the .sfg file ending with a specific pythonw/pyw executable, pass its path:
+#     powershell -ExecutionPolicy Bypass -File register_sfg_association.ps1 -PythonLauncherPath C:\path\to\pythonw.exe
+# This script also creates a per-user desktop shortcut named SignalFlowGrapher.lnk.
+# To remove the file association, run this script with the -Uninstall flag:
+#     powershell -ExecutionPolicy Bypass -File register_sfg_association.ps1 -Uninstall
+# Note: This script expects to be in the tools/windows directory of the repository. If you move it, you may need to adjust the paths to the icon and main script. You can execute this script from any location, but it will look for the repository files relative to its own location.
+
+param(
+    [switch]$Uninstall,
+    [string]$PythonLauncherPath
+)
+
+# Find the repository files we need: the app icon and the Python entrypoint.
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptDir '..\..')).Path
+$iconPath = Join-Path $repoRoot 'src\main\icons\Icon.ico'
+$mainScript = Join-Path $repoRoot 'src\main\python\main.py'
+
+if (-not (Test-Path $iconPath)) {
+    throw "Icon file not found: $iconPath"
+}
+
+if (-not (Test-Path $mainScript)) {
+    throw "Launcher script not found: $mainScript"
+}
+
+# Check for the GUI Python launcher to avoid flashing a console window when opening files.
+$pythonLauncher = $null
+if ($PythonLauncherPath) {
+    if (-not (Test-Path $PythonLauncherPath)) {
+        throw "Python launcher not found: $PythonLauncherPath"
+    }
+
+    $pythonLauncher = (Resolve-Path $PythonLauncherPath).Path
+} else {
+    foreach ($candidate in @('pythonw.exe', 'pyw.exe')) {
+        try {
+            $pythonLauncher = (Get-Command $candidate -ErrorAction Stop).Source
+            break
+        } catch {
+        }
+    }
+
+    if (-not $pythonLauncher) {
+        throw 'Could not find pythonw.exe or pyw.exe on PATH. Activate the environment that contains the GUI runtime, or pass -PythonLauncherPath to the launcher executable, then run this script again.'
+    }
+}
+
+$extension = '.sfg'
+$progId = 'SignalFlowGrapher.SFG'
+$shortcutPath = Join-Path ([Environment]::GetFolderPath('Desktop')) 'SignalFlowGrapher.lnk'
+$classesRoot = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Software\Classes', $true)
+
+$wshShell = New-Object -ComObject WScript.Shell
+
+if ($Uninstall) {
+    # Remove the file association if it was created by this script.
+    $extensionKey = $classesRoot.OpenSubKey($extension, $true)
+    if ($extensionKey) {
+        $currentValue = $extensionKey.GetValue('')
+        if ($currentValue -eq $progId) {
+            try {
+                $classesRoot.DeleteSubKeyTree($extension)
+            } catch {
+                Write-Host "Failed to delete registry key for $extension. You may need to remove it manually."
+            }
+        }
+        $extensionKey.Close()
+    }
+
+    try {
+        $classesRoot.DeleteSubKeyTree($progId)
+    } catch {
+        Write-Host "No registry entry found for $progId, skipping deletion."
+    }
+
+    if (Test-Path $shortcutPath) {
+        try {
+            Remove-Item $shortcutPath -Force
+        } catch {
+            Write-Host "Failed to delete shortcut at $shortcutPath. You may need to remove it manually."
+        }
+    }
+
+    Write-Host 'SignalFlowGrapher file association removed for .sfg'
+    exit 0
+}
+
+# Create the file type entry used by Windows Explorer for .sfg files.
+$progKey = $classesRoot.CreateSubKey($progId)
+$progKey.SetValue('', 'SignalFlowGrapher file')
+
+# Set the icon for .sfg files to the bundled application icon.
+$defaultIconKey = $progKey.CreateSubKey('DefaultIcon')
+$defaultIconKey.SetValue('', "$iconPath,0")
+$defaultIconKey.Close()
+
+# Define the action for opening .sfg files in Windows Explorer.
+$shellKey = $progKey.CreateSubKey('shell')
+$openKey = $shellKey.CreateSubKey('open')
+$commandKey = $openKey.CreateSubKey('command')
+$commandKey.SetValue('', "`"$pythonLauncher`" `"$mainScript`" `"%1`"")
+$commandKey.Close()
+$openKey.Close()
+$shellKey.Close()
+$progKey.Close()
+
+# Create the file extension entry in the registry for .sfg files.
+$extensionKey = $classesRoot.CreateSubKey($extension)
+$extensionKey.SetValue('', $progId)
+$extensionKey.Close()
+
+# Create a desktop shortcut that launches SignalFlowGrapher with the selected Python launcher.
+$shortcut = $wshShell.CreateShortcut($shortcutPath)
+$shortcut.TargetPath = $pythonLauncher
+$shortcut.Arguments = "`"$mainScript`""
+$shortcut.WorkingDirectory = $repoRoot
+$shortcut.IconLocation = "$iconPath,0"
+$shortcut.Description = 'SignalFlowGrapher'
+$shortcut.Save()
+
+# Confirm the association is active for this Windows account.
+Write-Host 'SignalFlowGrapher is now the default app for .sfg files in this Windows account.'
+Write-Host "Icon: $iconPath"
+Write-Host "Command: `"$pythonLauncher`" `"$mainScript`" `"%1`""
+Write-Host "Shortcut: $shortcutPath"


### PR DESCRIPTION
This pull request introduces a powershell script, to register the SignalFlowGrapher file ending `.sfg` for the local user on a Windows system. It also creates a shortcut for the SignalFlowGrapher on the Desktop, to quickly launch the application.

A README file provides a quick description of the scripts purpose and usage, as well as an example on how it can be used with an python virtual environment. Of course a command to uninstall and revert all changes exists as well in the script (using the `-Uninstall` flag)

This should (hopefully) make the usage of the tool for Windows easier!

*For Arch Linux users, I took the liberty to offer a [SignalFlowGrapher packet on the AUR](https://aur.archlinux.org/packages/signalflowgrapher-git), so linux users aren't left in the dust either :)*